### PR TITLE
DELETE WORDS WITH "COM" EXAMPLE "RECOMMEND" FIXED

### DIFF
--- a/plugins/links.lua
+++ b/plugins/links.lua
@@ -11,9 +11,9 @@ end
 return {
 patterns = {
     -- Agrega mas links si es necesario
-    "[Hh][Tt][Tt][Pp][Ss]://",
-    "[Hh][Tt][Tt][Pp]://",
-    "[Ww][Ww][Ww].",
-    ".[Cc][Oo][Mm]",
+    "[Hh][Tt][Tt][Pp][Ss][:][/][/]",
+    "[Hh][Tt][Tt][Pp][:][/][/]",
+    "[Ww][Ww][Ww][.]",
+    "[.][Cc][Oo][Mm]",
     "https?://[%w-_%.%?%.:/%+=&]+%"
 }, run = run}


### PR DESCRIPTION
El bot eliminaba palabras como reCOMendación debido a que el punto no lo tomaba antes y despúes de los corchetes.